### PR TITLE
Add Univention VP Software Engineering entry & CLAUDE.md

### DIFF
--- a/index.html
+++ b/index.html
@@ -73,7 +73,10 @@
                                     direction — beyond owning the engineering organisation. A core focus of mine is
                                     building and nurturing <strong>empowered product teams</strong>: teams that own
                                     outcomes rather than just shipping a backlog of stakeholder-driven features, and that
-                                    have the autonomy and context to make meaningful product decisions.
+                                    have the autonomy and context to make meaningful product decisions. I also drive the
+                                    adoption of <strong>AI-augmented coding</strong> across the engineering department,
+                                    ensuring we stay ahead of the curve when it comes to effective and modern development
+                                    practices.
                                 </p>
                                 <p class="title is-6"><i class="fa fa-lightbulb highlight-color"></i> Skills</p>
                                 <div class="tags are-medium">

--- a/index.html
+++ b/index.html
@@ -65,18 +65,15 @@
                                 <p class="subtitle is-6">May 2026 - <span class="tag is-info">today</span></p>
                                 <p>
                                     In May 2026, I joined <strong>Univention</strong> as VP Software Engineering.
-                                    Univention is a German open-source software company based in Bremen, specializing in
-                                    identity &amp; access management (IAM) and digital sovereignty solutions — trusted by
-                                    over 14,000 organizations and managing more than 35 million identities worldwide.
+                                    Univention is a Bremen-based open-source company specializing in identity &amp; access
+                                    management and digital sovereignty solutions.
                                 </p>
                                 <p>
-                                    In this role, I lead Univention's engineering teams in the development of their core
-                                    products, including <strong>Nubus</strong> — the modern open-source IAM platform —
-                                    as well as <strong>Univention Corporate Server (UCS)</strong> and
-                                    <strong>UCS@school</strong>. My responsibilities span engineering excellence, team
-                                    development, and aligning our technology roadmap with Univention's mission to enable
-                                    sovereign, self-determined IT infrastructure for the public sector, education, and
-                                    enterprises.
+                                    As part of the leadership team, I contribute to shaping the company's strategic
+                                    direction — beyond owning the engineering organisation. A core focus of mine is
+                                    building and nurturing <strong>empowered product teams</strong>: teams that own
+                                    outcomes rather than just shipping a backlog of stakeholder-driven features, and that
+                                    have the autonomy and context to make meaningful product decisions.
                                 </p>
                                 <p class="title is-6"><i class="fa fa-lightbulb highlight-color"></i> Skills</p>
                                 <div class="tags are-medium">

--- a/index.html
+++ b/index.html
@@ -57,12 +57,53 @@
                         <div class="media">
                             <div class="media-left">
                                 <figure class="image is-64x64">
+                                    <img src="images/univention.png" alt="Univention Logo">
+                                </figure>
+                            </div>
+                            <div class="media-content">
+                                <p class="title is-4">VP Software Engineering &#64; Univention</p>
+                                <p class="subtitle is-6">May 2026 - <span class="tag is-info">today</span></p>
+                                <p>
+                                    In May 2026, I joined <strong>Univention</strong> as VP Software Engineering.
+                                    Univention is a German open-source software company based in Bremen, specializing in
+                                    identity &amp; access management (IAM) and digital sovereignty solutions — trusted by
+                                    over 14,000 organizations and managing more than 35 million identities worldwide.
+                                </p>
+                                <p>
+                                    In this role, I lead Univention's engineering teams in the development of their core
+                                    products, including <strong>Nubus</strong> — the modern open-source IAM platform —
+                                    as well as <strong>Univention Corporate Server (UCS)</strong> and
+                                    <strong>UCS@school</strong>. My responsibilities span engineering excellence, team
+                                    development, and aligning our technology roadmap with Univention's mission to enable
+                                    sovereign, self-determined IT infrastructure for the public sector, education, and
+                                    enterprises.
+                                </p>
+                                <p class="title is-6"><i class="fa fa-lightbulb highlight-color"></i> Skills</p>
+                                <div class="tags are-medium">
+                                    <span class="tag">Leadership</span>
+                                    <span class="tag">Open Source</span>
+                                    <span class="tag">Digital Sovereignty</span>
+                                    <span class="tag">Strategic Thinking</span>
+                                    <span class="tag">Stakeholder Management</span>
+                                    <span class="tag">Team Building</span>
+                                    <span class="tag">Mentoring</span>
+                                </div>
+                                <p class="title is-6"><i class="fa fa-map-marked-alt highlight-color"></i> Location</p>
+                                <div class="tags are-medium">
+                                    <span class="tag">Bremen</span>
+                                </div>
+                            </div>
+                        </div>
+                        <hr>
+                        <div class="media">
+                            <div class="media-left">
+                                <figure class="image is-64x64">
                                     <img src="images/PMG.png" alt="ParshipMeet Group Logo">
                                 </figure>
                             </div>
                             <div class="media-content">
                                 <p class="title is-4">Group VP Engineering &#64; ParshipMeet Group</p>
-                                <p class="subtitle is-6">November 2025 - <span class="tag is-info">today</span></p>
+                                <p class="subtitle is-6">November 2025 - April 2026</p>
                                 <p>
                                     In November 2025, I was honored to be promoted to the role of <strong>Group VP Engineering</strong> at ParshipMeet Group.
                                     In this elevated position, I oversee the entire engineering division, guiding a talented team of over 100 engineers.

--- a/index.html
+++ b/index.html
@@ -75,8 +75,7 @@
                                     outcomes rather than just shipping a backlog of stakeholder-driven features, and that
                                     have the autonomy and context to make meaningful product decisions. I also drive the
                                     adoption of <strong>AI-augmented coding</strong> across the engineering department,
-                                    ensuring we stay ahead of the curve when it comes to effective and modern development
-                                    practices.
+                                    ensuring we remain current with modern and effective development practices.
                                 </p>
                                 <p class="title is-6"><i class="fa fa-lightbulb highlight-color"></i> Skills</p>
                                 <div class="tags are-medium">


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Added `CLAUDE.md` with codebase guidance for AI assistants
- Closed ParshipMeet Group VP Engineering entry at April 2026
- Added new Univention VP Software Engineering entry (May 2026 – today), covering empowered product teams, strategic leadership, and AI-augmented coding adoption

https://claude.ai/code/session_01Y1xezSERwPXMEfQqJGSR3U
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y1xezSERwPXMEfQqJGSR3U)_